### PR TITLE
Rounding of the raw data should happen on the client side

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ const sht31 = new SHT31(); // Paramteres unecessary when using a B+, A+, Zero, Z
 sht31.readSensorData().then((data) => {
   // I love arrow notation functions inside of promises.
 
-  // Temp in Fahrenheit -- this is already rounded to one digit (accuracy is .2 degress, the other digits have no value) Multiplying it can cause some JS floating point weirdness, we just round it off here.
+  // Temp in Fahrenheit
   const temp = Math.round(data.temperature * 1.8 + 32);
-  const humidity = data.humidity;
+  const humidity = Math.round(data.humidity);
 
   console.log(`The temperature is: ${temp} degress F\nThe Humidity is: ${humidity}%`); // Template strings are great.
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ const sht31 = new SHT31(); // Paramteres unecessary when using a B+, A+, Zero, Z
 sht31.readSensorData().then((data) => {
   // I love arrow notation functions inside of promises.
 
-  // Temp in Fahrenheit
+  // Temp in Fahrenheit -- If you get floating point rouding errors, multiply by ten before rouding, divide by 10 after.
   const temp = Math.round(data.temperature * 1.8 + 32);
   const humidity = Math.round(data.humidity);
 

--- a/examples/typical_usage.js
+++ b/examples/typical_usage.js
@@ -7,7 +7,7 @@ const sht31 = new SHT31(); // Paramteres unecessary when using a B+, A+, Zero, Z
 sht31.readSensorData().then((data) => {
   // I love arrow notation functions inside of promises.
   const temp = Math.round(data.temperature * 1.8 + 32); // Temp in Fahrenheit
-  const humidity = data.humidity;
+  const humidity = Math.round(data.humidity);
 
   console.log(`The temperature is: ${temp} degress F\nThe Humidity is: ${humidity}%`); // Template strings are great.
 

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -32,11 +32,11 @@ function delay(ms){
 }
 
 function formatTemperature(rawTemp){
-  return Math.round( (((rawTemp * 175) / 0xFFFF) - 45) * 10 ) / 10; // Accurate +/- .2 degress
+  return ((rawTemp * 175) / 0xFFFF) - 45;
 }
 
 function formatHumidity(rawHumidity){
-  return Math.round( (rawHumidity * 100) / 0xFFFF);
+  return (rawHumidity * 100) / 0xFFFF;
 }
 
 module.exports = { checksum, i2cBusPromiseWrapper, delay, formatTemperature, formatHumidity };


### PR DESCRIPTION
Hi David,

Thanks a lot for this library talking to the SHT3x sensor using i2c-bus, it's very useful.

The following PR suggests a small change: I believe that the rounding of the raw temperature and humidity data should not be part of the library, but should instead be left up to the client.

I understand that in the best case scenario (SHT35 sensor) the stated temperature accuracy is ±0.1ºC, and the RH accuracy is ±1.5%, but that doesn't mean the extra digit precision is irrelevant, it still conveys actual information. (https://en.wikipedia.org/wiki/Accuracy_and_precision)

What do you think?